### PR TITLE
Add scripts for converting select NWB HDF5 files to Zarr

### DIFF
--- a/zarr_convert/convert_files.sh
+++ b/zarr_convert/convert_files.sh
@@ -6,13 +6,13 @@ conda activate nwb_zarr
 
 # Download the file
 if ! test -f sub-npI3_ses-20190421_behavior+ecephys.nwb; then
-	wget https://api.dandiarchive.org/api/assets/ac03f90d-746b-48b1-8c12-0416fdaa79cc/download/
+	dandi download https://api.dandiarchive.org/api/assets/ac03f90d-746b-48b1-8c12-0416fdaa79cc/download/
 fi
 if ! test -f sub-R6_ses-20200206T210000_behavior+ophys.nwb; then
-	wget https://api.dandiarchive.org/api/assets/11ef11cc-130b-4d22-8af0-aa4798c64584/download/
+	dandi download https://api.dandiarchive.org/api/assets/11ef11cc-130b-4d22-8af0-aa4798c64584/download/
 fi
 if ! test -f sub-1214579789_ses-1214621812_icephys.nwb; then
-	wget https://api.dandiarchive.org/api/assets/1142cd85-96f9-4ae2-9d71-f722887fb3c0/download/
+	dandi download https://api.dandiarchive.org/api/assets/1142cd85-96f9-4ae2-9d71-f722887fb3c0/download/
 fi
 
 # Convert the files

--- a/zarr_convert/convert_files.sh
+++ b/zarr_convert/convert_files.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This script is used to download a set of example NWB files from DANDI and convert the files from HDF5 to Zarr
+# Note: This script assumes that the create_conda_env.sh script has been run to setup the nwb_zarr conda environment
+
 # activate the python env
 module load conda
 conda activate nwb_zarr

--- a/zarr_convert/convert_files.sh
+++ b/zarr_convert/convert_files.sh
@@ -16,15 +16,19 @@ if ! test -f sub-1214579789_ses-1214621812_icephys.nwb; then
 fi
 
 # Convert the files
+echo "Converting sub-npI3_ses-20190421_behavior+ecephys.nwb"
 if ! test -f sub-npI3_ses-20190421_behavior+ecephys.nwb.zarr; then
 	python nwb_hdf_to_zarr.py sub-npI3_ses-20190421_behavior+ecephys.nwb
 fi
-
+echo "DONE"
+echo "Converting sub-R6_ses-20200206T210000_behavior+ophys.nwb.zarr"
 if ! test -f sub-R6_ses-20200206T210000_behavior+ophys.nwb.zarr; then
         python nwb_hdf_to_zarr.py sub-R6_ses-20200206T210000_behavior+ophys.nwb
 fi
-
+echo "DONE"
+echo "Converting sub-1214579789_ses-1214621812_icephys.nwb.zarr"
 if ! test -f sub-1214579789_ses-1214621812_icephys.nwb.zarr; then
         python nwb_hdf_to_zarr.py sub-1214579789_ses-1214621812_icephys.nwb
 fi
+echo "DONE"
 

--- a/zarr_convert/convert_files.sh
+++ b/zarr_convert/convert_files.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# activate the python env
+module load conda
+conda activate nwb_zarr
+
+# Download the file
+if ! test -f sub-npI3_ses-20190421_behavior+ecephys.nwb; then
+	wget https://api.dandiarchive.org/api/assets/ac03f90d-746b-48b1-8c12-0416fdaa79cc/download/
+fi
+if ! test -f sub-R6_ses-20200206T210000_behavior+ophys.nwb; then
+	wget https://api.dandiarchive.org/api/assets/11ef11cc-130b-4d22-8af0-aa4798c64584/download/
+fi
+if ! test -f sub-1214579789_ses-1214621812_icephys.nwb; then
+	wget https://api.dandiarchive.org/api/assets/1142cd85-96f9-4ae2-9d71-f722887fb3c0/download/
+fi
+
+# Convert the files
+if ! test -f sub-npI3_ses-20190421_behavior+ecephys.nwb.zarr; then
+	python nwb_hdf_to_zarr.py sub-npI3_ses-20190421_behavior+ecephys.nwb
+fi
+
+if ! test -f sub-R6_ses-20200206T210000_behavior+ophys.nwb.zarr; then
+        python nwb_hdf_to_zarr.py sub-R6_ses-20200206T210000_behavior+ophys.nwb
+fi
+
+if ! test -f sub-1214579789_ses-1214621812_icephys.nwb.zarr; then
+        python nwb_hdf_to_zarr.py sub-1214579789_ses-1214621812_icephys.nwb
+fi
+

--- a/zarr_convert/create_conda_env.sh
+++ b/zarr_convert/create_conda_env.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Create a conda environment at NERSC with hdmf and hdmf-zarr installed
 
 module load conda
 conda create --name nwb_zarr python=3.11
@@ -16,5 +17,4 @@ git clone https://github.com/hdmf-dev/hdmf-zarr.git
 cd hdmf-zarr
 pip install -r requirements.txt -r requirements-dev.txt -r requirements-doc.txt
 pip install -e .
-
 

--- a/zarr_convert/create_conda_env.sh
+++ b/zarr_convert/create_conda_env.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+module load conda
+conda create --name nwb_zarr python=3.11
+conda activate nwb_zarr
+conda install h5py
+
+git clone --recurse-submodules https://github.com/hdmf-dev/hdmf.git
+cd hdmf
+pip install -r requirements.txt -r requirements-dev.txt -r requirements-doc.txt -r requirements-opt.txt
+pip install -e .
+cd ..
+
+git clone https://github.com/hdmf-dev/hdmf-zarr.git
+cd hdmf-zarr
+pip install -r requirements.txt -r requirements-dev.txt -r requirements-doc.txt
+pip install -e .
+
+

--- a/zarr_convert/create_conda_env.sh
+++ b/zarr_convert/create_conda_env.sh
@@ -4,6 +4,7 @@ module load conda
 conda create --name nwb_zarr python=3.11
 conda activate nwb_zarr
 conda install h5py
+pip install dandi
 
 git clone --recurse-submodules https://github.com/hdmf-dev/hdmf.git
 cd hdmf

--- a/zarr_convert/nwb_hdf_to_zarr.py
+++ b/zarr_convert/nwb_hdf_to_zarr.py
@@ -1,3 +1,7 @@
+"""
+Convert an NWB HDF5 file to Zarr
+"""
+
 from pynwb import NWBHDF5IO
 from hdmf_zarr.nwb import NWBZarrIO
 import sys
@@ -21,9 +25,4 @@ if __name__ == "__main__":
         hdf_filename = sys.argv[1]
         zarr_filename = hdf_filename +".zarr"
         convert(hdf_filename=hdf_filename, zarr_filename=zarr_filename)
-
-
-
-
-
 

--- a/zarr_convert/nwb_hdf_to_zarr.py
+++ b/zarr_convert/nwb_hdf_to_zarr.py
@@ -8,7 +8,7 @@ def print_help():
     print("")
     print("The output zarr file will be named the same as the HDF5 file with the added .zarr extension")
 
-def convert(hdf_filename: str, zarr_filename: str)
+def convert(hdf_filename: str, zarr_filename: str):
     with NWBHDF5IO(hdf_filename, 'r', load_namespaces=True) as read_io:  # Create HDF5 IO object for read
         with NWBZarrIO(zarr_filename, mode='w') as export_io:         # Create Zarr IO object for write
             export_io.export(src_io=read_io, write_args=dict(link_data=False))   # Export from HDF5 to Zarr

--- a/zarr_convert/nwb_hdf_to_zarr.py
+++ b/zarr_convert/nwb_hdf_to_zarr.py
@@ -1,0 +1,29 @@
+from pynwb import NWBHDF5IO
+from hdmf_zarr.nwb import NWBZarrIO
+import sys
+
+def print_help():
+    print("The script requires exactly one arguments. Call with")
+    print("python nwb_hdf_to_zarr.py <hdf5_filename>")
+    print("")
+    print("The output zarr file will be named the same as the HDF5 file with the added .zarr extension")
+
+def convert(hdf_filename: str, zarr_filename: str)
+    with NWBHDF5IO(hdf_filename, 'r', load_namespaces=True) as read_io:  # Create HDF5 IO object for read
+        with NWBZarrIO(zarr_filename, mode='w') as export_io:         # Create Zarr IO object for write
+            export_io.export(src_io=read_io, write_args=dict(link_data=False))   # Export from HDF5 to Zarr
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print_help()
+        exit(0)
+    else:
+        hdf_filename = sys.argv[1]
+        zarr_filename = hdf_filename +".zarr"
+        convert(hdf_filename=hdf_filename, zarr_filename=zarr_filename)
+
+
+
+
+
+


### PR DESCRIPTION
Add scripts for converting NWB HDF5 files to Zarr. This PR includes

- Shell script to create a conda environment with hdmf and hdmf-zarr installed in developer mode at NERSC
- Shell script to download and convert 3 example files from DANDI from HDF5 to Zarr
- Python script to convert a single, user-defined NWB HDF5 file to Zarr